### PR TITLE
Fix for config_flow.py

### DIFF
--- a/custom_components/hafele_connect_mesh/config_flow.py
+++ b/custom_components/hafele_connect_mesh/config_flow.py
@@ -89,7 +89,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Create a bulleted list of networks
         networks_info = (
-            "\n• " + "\n• ".join([f"{net['name']}" for net in self.networks]) + "\n"
+            "\n\u2713 " + "\u2713 ".join([f"{net['name']}" for net in self.networks]) + "\n"
         )
 
         return self.async_show_form(

--- a/custom_components/hafele_connect_mesh/config_flow.py
+++ b/custom_components/hafele_connect_mesh/config_flow.py
@@ -87,13 +87,19 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required("network"): vol.In({net["id"]: net["name"] for net in self.networks})
         })
 
+        # Create a bulleted list of networks
+        networks_info = (
+            "\n• " + "\n• ".join([f"{net['name']}" for net in self.networks]) + "\n"
+        )
+
         return self.async_show_form(
             step_id="select_network",
             data_schema=network_schema,
             errors=errors,
             description_placeholders={
-                "select_info": "Please select one network to add to Home Assistant."
-            }
+                "select_info": "Please select one network to add to Home Assistant.",
+                "networks": networks_info,
+            },
         )
 
     async def async_step_process_devices(self, user_input=None) -> FlowResult:

--- a/custom_components/hafele_connect_mesh/translations/en.json
+++ b/custom_components/hafele_connect_mesh/translations/en.json
@@ -5,7 +5,7 @@
           "description": "Please enter your Häfele Connect Mesh API key."
         },
         "select_network": {
-          "description": "Found networks: {networks}. If no networks are found, make sure everything is correctly set up in the Connect Mesh app."
+          "description": "Found networks:\n{networks}\nIf no networks are found, make sure everything is correctly set up in the Connect Mesh app."
         }
       },
       "error": {
@@ -16,4 +16,3 @@
       }
     }
   }
-  


### PR DESCRIPTION
During the setup I got an error message:

 `2024-10-28 20:41:56.468 ERROR (MainThread) [frontend.js.modern.202410024] Failed to format translation for key 'component.hafele_connect_mesh.config.step.select_network.description' in language 'en'. Error: The intl string context variable "networks" was not provided to the string "Found networks: {networks}. If no networks are found, make sure everything is correctly set up in the Connect Mesh app."`
 
 This fixes that error